### PR TITLE
Add a meta label for the task slot number

### DIFF
--- a/discovery/swarm/swarm.go
+++ b/discovery/swarm/swarm.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +51,8 @@ const (
 	nodeIPLabel model.LabelName = metaLabelPrefix + "node_ip"
 	// nodeNameLabel contains the node name.
 	nodeNameLabel model.LabelName = metaLabelPrefix + "node_name"
+	// slotLabel contains the task slot.
+	taskSlotLabel model.LabelName = metaLabelPrefix + "task_slot"
 
 	// Constants for instrumentation.
 	namespace = "prometheus"
@@ -366,11 +369,13 @@ func (d *Discovery) targetsForService(service *Service, nodes map[string]*Node) 
 
 			addr := d.getTaskAddr(&t, network, node)
 			if addr != "" {
+				// DEBUG
 				target := model.LabelSet{
 					model.AddressLabel: model.LabelValue(net.JoinHostPort(addr, port)),
 					taskLabel:          model.LabelValue(t.ID),
 					nodeIPLabel:        model.LabelValue(d.getNodeIP(node)),
 					nodeNameLabel:      model.LabelValue(d.getNodeName(node)),
+					taskSlotLabel:      model.LabelValue(strconv.Itoa(t.Slot)),
 				}
 				if path != "" {
 					target[model.MetricsPathLabel] = model.LabelValue(path)
@@ -450,6 +455,7 @@ type Task struct {
 		}
 		Addresses []string
 	}
+	Slot int
 }
 
 // Node is an instance of the Engine participating in a swarm.

--- a/discovery/swarm/swarm.go
+++ b/discovery/swarm/swarm.go
@@ -369,7 +369,6 @@ func (d *Discovery) targetsForService(service *Service, nodes map[string]*Node) 
 
 			addr := d.getTaskAddr(&t, network, node)
 			if addr != "" {
-				// DEBUG
 				target := model.LabelSet{
 					model.AddressLabel: model.LabelValue(net.JoinHostPort(addr, port)),
 					taskLabel:          model.LabelValue(t.ID),


### PR DESCRIPTION
This PR adds a Meta label for the task slot
With this, user can map label in prometheus conf

Without that, the unique way to differenciate task is by task id or ip address
I think the service name and task slot is a better way to identify a task in swarm mode