### PR TITLE
WIP: Swarm service mode (VIP)

### DIFF
--- a/discovery/swarm/swarm.go
+++ b/discovery/swarm/swarm.go
@@ -61,8 +61,6 @@ const (
 	apiVersion = "1.32"
 	// labelPrefix is the prefix of service labels used for filtering in this discovery.
 	labelPrefix = "prometheus."
-	// labelPrefixServiceRole is the prefix of service labels used for filtering in this discovery.
-	labelPrefixServiceRole = "prometheus.service."
 )
 
 var (
@@ -225,46 +223,30 @@ func (d *Discovery) updateServices(ctx context.Context, ch chan<- []*targetgroup
 }
 
 func (d *Discovery) fetchTargetGroups() (map[string]*targetgroup.Group, error) {
+	services, err := d.fetchServices()
+	if err != nil {
+		return nil, err
+	}
+
 	nodes, err := d.fetchNodes()
 	if err != nil {
 		return nil, err
 	}
 
 	groups := map[string]*targetgroup.Group{}
-
-	// Fetch services for tasks
-	services, err := d.fetchServices(labelPrefix)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, service := range services {
 		if len(service.Tasks) > 0 {
-			group := d.createTargetGroup(labelPrefix, service, nodes)
+			group := d.createTargetGroup(service, nodes)
 			groups[group.Source] = group
 		}
 	}
-
-	// Fetch services in service Role
-	services, err = d.fetchServices(labelPrefixServiceRole)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, service := range services {
-		if len(service.Tasks) > 0 {
-			group := d.createTargetGroup(labelPrefixServiceRole, service, nodes)
-			groups[group.Source] = group
-		}
-	}
-
 	return groups, nil
 }
 
-func (d *Discovery) createTargetGroup(prefix string, service *Service, nodes map[string]*Node) *targetgroup.Group {
+func (d *Discovery) createTargetGroup(service *Service, nodes map[string]*Node) *targetgroup.Group {
 	g := &targetgroup.Group{
-		Source:  prefix + service.Spec.Name,
-		Targets: d.targetsForService(prefix, service, nodes),
+		Source:  service.Spec.Name,
+		Targets: d.targetsForService(service, nodes),
 		Labels: model.LabelSet{
 			serviceLabel: model.LabelValue(service.Spec.Name),
 			imageLabel:   model.LabelValue(service.Spec.TaskTemplate.ContainerSpec.Image),
@@ -278,9 +260,9 @@ func (d *Discovery) createTargetGroup(prefix string, service *Service, nodes map
 }
 
 // fetchServices requests a list of services from Swarm cluster.
-func (d *Discovery) fetchServices(prefix string) ([]*Service, error) {
+func (d *Discovery) fetchServices() ([]*Service, error) {
 	filters := Args{}
-	filters.Add("label", prefix+"enable=true")
+	filters.Add("label", labelPrefix+"enable=true")
 	body, err := d.request("/services", filters)
 	if err != nil {
 		return nil, err
@@ -368,19 +350,32 @@ func (d *Discovery) request(path string, args Args) ([]byte, error) {
 	return body, nil
 }
 
-func (d *Discovery) targetsForService(prefix string, service *Service, nodes map[string]*Node) []model.LabelSet {
+func (d *Discovery) targetsForService(service *Service, nodes map[string]*Node) []model.LabelSet {
 	targets := make([]model.LabelSet, 0, len(service.Tasks))
-	network := service.Spec.Labels[prefix+"network"]
+	network := service.Spec.Labels[labelPrefix+"network"]
 	if network == "" {
 		network = d.network
 	}
-	port := service.Spec.Labels[prefix+"port"]
-	path := service.Spec.Labels[prefix+"path"]
-	group := service.Spec.Labels[prefix+"group"]
-	//scheme := service.Spec.Labels[prefix+"scheme"]
+	mode := service.Spec.Labels[labelPrefix+"mode"]
+	port := service.Spec.Labels[labelPrefix+"port"]
+	path := service.Spec.Labels[labelPrefix+"path"]
+	group := service.Spec.Labels[labelPrefix+"group"]
+	//scheme := service.Spec.Labels[labelPrefix+"scheme"]
 	if port != "" && group == d.group {
-		if prefix == labelPrefix {
-			// Pod mode, we retrieve tasks for targets
+		if mode == "service" {
+			// Service mode, we only get the VIP as target
+			addr := d.getServiceAddr(service, network)
+			if addr != "" {
+				target := model.LabelSet{
+					model.AddressLabel: model.LabelValue(net.JoinHostPort(addr, port)),
+				}
+				if path != "" {
+					target[model.MetricsPathLabel] = model.LabelValue(path)
+				}
+				targets = append(targets, target)
+			}
+		} else {
+			// Task mode, we retrieve tasks for targets
 			for _, t := range service.Tasks {
 				node, ok := nodes[t.NodeID]
 				if !ok {
@@ -401,18 +396,6 @@ func (d *Discovery) targetsForService(prefix string, service *Service, nodes map
 					}
 					targets = append(targets, target)
 				}
-			}
-		} else {
-			// Service mode, we only get the VIP as target
-			addr := d.getServiceAddr(service, network)
-			if addr != "" {
-				target := model.LabelSet{
-					model.AddressLabel: model.LabelValue(net.JoinHostPort(addr, port)),
-				}
-				if path != "" {
-					target[model.MetricsPathLabel] = model.LabelValue(path)
-				}
-				targets = append(targets, target)
 			}
 		}
 	}


### PR DESCRIPTION
A first attempt to discover services endpoints (VIP)
New label `prometheus.mode`
To switch to service mode, juste set `prometheus.mode=service`

/closes #5 

for testing, i do : 
```
docker service create \
--network prom_net \
-l "prometheus.enable=true" \
-l "prometheus.mode=service" \
-l "prometheus.port=80" \
-l "prometheus.network=prom_net" \
-l "prometheus.path=/service-path" \
--replicas=5 \
--name=nginxtest \
nginx:alpine
```

Prometheus should discover only 1 target on the swarm service VIP
- VIP:80/service-path